### PR TITLE
Cache object values in get_cl_info

### DIFF
--- a/passyunk/parser.py
+++ b/passyunk/parser.py
@@ -84,6 +84,11 @@ class Address:
         self.responsibility = ''
         self.cl_addr_match = ''
 
+    def __str__(self):
+        return 'Address: {}'.format(self.street_address)
+
+    def __repr__(self):
+        return self.__str__()
 
 class Unit:
     def __init__(self):


### PR DESCRIPTION
Some of the comparisons in `get_cl_info` were getting object values (e.g. `centerline.from_left`) more than once. Caching them in the beginning speeds it up by about 40%.
