### PR TITLE
Add utf-8 encoding to opening of landmarks csv

### DIFF
--- a/passyunk/landmark.py
+++ b/passyunk/landmark.py
@@ -22,7 +22,7 @@ class Landmark:
         path = self.csv_path('landmarks')
         landmark_dict = {}
         try:
-            with open(path, 'r') as f:
+            with open(path, 'r', encoding='utf-8') as f:
                 reader = csv.reader(f)
                 for row in reader:
                     # Don't match on 'the' as first word


### PR DESCRIPTION
Fixes a bug that may have been introduced when we switched over the source tables for `landmarks.csv`.
 
When `parser.parse()` reaches the point where it checks whether the input might fuzzy-match a landmark name, calls `list_landmarks()`, and iterates through the rows of `landmarks.csv` (line 25), it eventually throws the error message: 
 
`UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d in position 1560: character maps to <undefined>`
 
What this means in practice is that a lot of uncertain/slightly messy inputs cause errors that halt execution of `parser.parse()`. It also seems like any input that tries to correspond to a landmark name results in an error.

The main reason for this seems to be that the `viewer_ng911.named_places` tables (the new sources for `landmark.csv`) have several non-ASCII characters, both overtly visible and hidden. Adding a keyword argument `encoding='utf-8'` resolves the issue. (a quick look at the old landmarks list suggests that it had just two accented characters -- an é  and an ó -- and no other non-ASCII characters, so an explicit encoding wasn't necessary.)


 

 